### PR TITLE
LocalPeer: Fix warning

### DIFF
--- a/libraries/LocalPeer/src/LocalPeer.cpp
+++ b/libraries/LocalPeer/src/LocalPeer.cpp
@@ -122,6 +122,14 @@ LocalPeer::LocalPeer(QObject * parent, const ApplicationId &appId)
     QString lockName = QDir(QDir::tempPath()).absolutePath() + QLatin1Char('/') + socketName + QLatin1String("-lockfile");
     lockFile.reset(new LockedFile(lockName));
     lockFile->open(QIODevice::ReadWrite);
+
+    if (!server->isListening())
+    {
+        if (!server->listen(socketName))
+        {
+            // handle warning
+        }
+    }
 }
 
 LocalPeer::~LocalPeer()


### PR DESCRIPTION
This will check if the QLocalServer object is already listening for connections before trying to start it again, and will only start it if it is not already listening.

This should fix the "QLocalSocket::setServerName() called while not in unconnected state" warning.

Signed-off-by: Edgars Cīrulis <edgarsscirulis@gmail.com>

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
